### PR TITLE
Update bcdc_licenses.json to incorporate changes to SkilledTradesBC

### DIFF
--- a/ckanext/bcgov_schema/bcdc_licenses.json
+++ b/ckanext/bcgov_schema/bcdc_licenses.json
@@ -192,8 +192,8 @@
         "maintainer": "",
         "status": "active",
         "is_open": false,
-        "title": "Open Government Licence – Industry Training Authority",
-        "url": "https://itabc.ca/sites/default/files/docs/ITA_Open_Government_Licence_Final.pdf"
+        "title": "Open Government Licence - SkilledTradesBC",
+        "url": "https://skilledtradesbc.ca/sites/default/files/2023-09/SkilledTradesBC_Open_Government_Licence_Final.pdf"
     },
 	{
         "domain_content": false,


### PR DESCRIPTION
Ticket: DATABC-2689 (https://dpdd.atlassian.net/browse/DATABC-2689) Updated license title for "Open Government Licence - Industry Training Authority" to "Open Government Licence - SkilledTradesBC" Updated license url to https://skilledtradesbc.ca/sites/default/files/2023-09/SkilledTradesBC_Open_Government_Licence_Final.pdf